### PR TITLE
feat: migrate some code from core into cli by tappable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     'playground',
     'examples'
   ],
-  'coverageDirectory': './coverage/',
-  'collectCoverage': true
+  coverageDirectory: './coverage/',
+  collectCoverage: true
 }
 

--- a/packages/serendipity-cli/src/hooksRegister.ts
+++ b/packages/serendipity-cli/src/hooksRegister.ts
@@ -1,0 +1,50 @@
+/*
+ * File: hooksRegister.ts
+ * Description: hooks 注册函数集合
+ * Created: 2021-3-16 14:56:25
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+
+import { CoreManager } from '@attachments/serendipity-core'
+import { chalk, logger } from '@attachments/serendipity-public'
+
+export const registerCreateHook = (manager: CoreManager) => {
+  const coreManagerHooks = manager.getCoreManagerHooks()
+  coreManagerHooks.onCreateStart.tap('beforePluginInstall', (instance) => {
+    logger.info(`🚀 在 ${chalk.yellow(instance.getBasePath())} 创建项目中...\n`)
+  })
+
+  coreManagerHooks.onCreateSuccess.tap('onRunningSuccess', () => {
+    // 成功提示
+    logger.done(`✨ 创建项目成功~, happy coding!`)
+  })
+
+  coreManagerHooks.onCreateValidateError.tap('onCreateValidateError', () => {
+    logger.error('preset 为空，请选择一个正确的 preset，可以是一个本地路径或者 http url')
+  })
+
+  coreManagerHooks.onAddStart.tap('onAddStart', ({ name }) => {
+    logger.info(`添加插件 ${name} 中...`)
+  })
+
+  coreManagerHooks.onAddValidateError.tap('onAddValidateError', ({ name }) => {
+    logger.error(`${name} 不是一个合法的插件名称，名称应该以 serendipity-plugin 或者 @attachments/serendipity-plugin 开头`)
+  })
+
+  coreManagerHooks.onPluginInstallSuccess.tap('onPluginInstallSuccess', ({ name }) => {
+    logger.info(`插件 ${name} 安装成功!`)
+  })
+
+  coreManagerHooks.beforePluginDelete.tap('beforePluginDelete', () => {
+    logger.info('正在移除无关的依赖...')
+  })
+
+  coreManagerHooks.afterPluginDelete.tap('afterPluginDelete', () => {
+    logger.info('移除成功!')
+  })
+
+  coreManagerHooks.onInitWorkDirFail.tap('onInitWorkDirFail', () => {
+    logger.error('该目录已经存在，请删除旧目录或者在其他目录下执行创建命令！')
+  })
+}

--- a/packages/serendipity-cli/src/serendipity.ts
+++ b/packages/serendipity-cli/src/serendipity.ts
@@ -12,6 +12,7 @@ import { program } from 'commander'
 import { CreateOptions } from '@attachments/serendipity-public/bin/types/common'
 import { CoreManager } from '@attachments/serendipity-core'
 import { AddOption } from '@attachments/serendipity-core/bin/types/options'
+import { registerCreateHook } from './hooksRegister'
 
 
 // 版本信息
@@ -28,6 +29,10 @@ program
   .action(async (name: string, opt: CreateOptions) => {
     // 初始化 manager
     const manager = new CoreManager()
+
+    manager.getCoreManagerHooks()
+
+    registerCreateHook(manager)
 
     // 执行创建脚本
     await manager.create(name, opt)

--- a/packages/serendipity-cli/src/serendipity.ts
+++ b/packages/serendipity-cli/src/serendipity.ts
@@ -30,8 +30,7 @@ program
     // 初始化 manager
     const manager = new CoreManager()
 
-    manager.getCoreManagerHooks()
-
+    // 注册钩子
     registerCreateHook(manager)
 
     // 执行创建脚本
@@ -48,6 +47,10 @@ program
   .action(async (name: string, opt: AddOption) => {
     // 初始化 manager
     const manager = new CoreManager()
+
+    // 注册钩子
+    registerCreateHook(manager)
+
     await manager.add(name, opt)
   })
 

--- a/packages/serendipity-core/__tests__/pluginExecutor.spec.ts
+++ b/packages/serendipity-core/__tests__/pluginExecutor.spec.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs'
 import { SyncHook } from 'tapable'
 import { generateTempPathInfo } from '@attachments/serendipity-public'
 import { ConstructionOptions, ScriptOptions } from '../src/types/pluginExecute'
-import { Construction, Inquiry, Runtime, Script, SerendipityPlugin } from '../src/decorators'
+import { Construction, Inquiry, Runtime, Script, SerendipityPlugin } from '../src'
 import PluginExecutor from '../src/pluginExecutor'
 
 

--- a/packages/serendipity-core/package.json
+++ b/packages/serendipity-core/package.json
@@ -11,7 +11,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@attachments/serendipity-public": "^0.1.8"
+    "@attachments/serendipity-public": "^0.1.8",
+    "tapable": "^2.2.0"
   },
   "files": [
     "bin"

--- a/packages/serendipity-core/src/appManager.ts
+++ b/packages/serendipity-core/src/appManager.ts
@@ -11,9 +11,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { AppConfig, CommonObject } from '@attachments/serendipity-public/bin/types/common'
 import { PluginModuleInfo } from '@attachments/serendipity-public/bin/types/plugin'
-import { isPlugin, writeFilePromise } from '@attachments/serendipity-public/bin/utils/files'
-import PackageManager from '@attachments/serendipity-public/src/utils/packageManager'
-import logger from '@attachments/serendipity-public/bin/utils/logger'
+import { isPlugin, writeFilePromise, PackageManager, logger } from '@attachments/serendipity-public'
+
 
 class AppManager {
   private readonly basePath: string

--- a/packages/serendipity-core/src/hooks/coreManagerHooks.ts
+++ b/packages/serendipity-core/src/hooks/coreManagerHooks.ts
@@ -1,0 +1,45 @@
+/*
+ * File: coreManagerHooks.ts
+ * Description: core manager 生命周期钩子
+ * Created: 2021-3-16 13:44:32
+ * Author: yuzhanglong
+ * Email: yuzl1123@163.com
+ */
+
+import { SyncHook } from 'tapable'
+import { CreateOptions } from '@attachments/serendipity-public/bin/types/common'
+import CoreManager from '../coreManager'
+import { AddOption } from '../types/options'
+
+const createCoreManagerHooks = () => {
+  return {
+    onCreateStart: new SyncHook<CoreManager>(['coreManagerInstance']),
+
+    onCreateSuccess: new SyncHook<CoreManager>(['coreManagerInstance']),
+
+    onCreateValidateError: new SyncHook<CreateOptions>(['CreateOptions']),
+
+    onAddValidateError: new SyncHook<{
+      name: string,
+      option: AddOption
+    }>(['nameAndOpts']),
+
+    onAddStart: new SyncHook<{
+      name: string,
+      option: AddOption
+    }>(['nameAndOpts']),
+
+    onPluginInstallSuccess: new SyncHook<{
+      name: string,
+      option: AddOption
+    }>(['nameAndOpts']),
+
+    beforePluginDelete: new SyncHook(),
+
+    afterPluginDelete: new SyncHook(),
+
+    onInitWorkDirFail: new SyncHook()
+  }
+}
+
+export default createCoreManagerHooks

--- a/packages/serendipity-plugin-init/templates/plugin-template/src/MyPlugin.ts
+++ b/packages/serendipity-plugin-init/templates/plugin-template/src/MyPlugin.ts
@@ -1,5 +1,5 @@
-import { Construction, Inquiry, Runtime, Script, SerendipityPlugin } from '@attachments/serendipity-scripts'
-import { ConstructionOptions, RuntimeOptions } from '@attachments/serendipity-scripts/bin/types/pluginExecute'
+import { Construction, Inquiry, Runtime, Script, SerendipityPlugin } from '@attachments/serendipity-core'
+import { ConstructionOptions, RuntimeOptions } from '@attachments/serendipity-core/bin/types/pluginExecute'
 
 
 @SerendipityPlugin('my-plugin')


### PR DESCRIPTION
- [x] 通过 tapable 机制，抽离 core package 的部分代码（例如给用户的 logger，这部分理应放在 cli 模块中），通过 hooks 将生命周期暴露给调用者
- [x] 更新 cli 部分代码以适配